### PR TITLE
tonic 0.8 and prost 0.11 upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The list of available features can be found [here](./google-api-proto/Cargo.toml
 |------------------|-------|-------------|
 | 1.0.0 ≦          | 0.6.x | 0.6.x       |
 | 1.59.0 ≦         | 0.7.x | 0.7.x       |
-| 1.217.0 ≦        | 0.8.x | 0.8.x       |
+| 1.218.0 ≦        | 0.8.x | 0.8.x       |
 
 ## Example
 The complete code can be found [here](./examples/src/spanner.rs).

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The list of available features can be found [here](./google-api-proto/Cargo.toml
 |------------------|-------|-------------|
 | 1.0.0 ≦          | 0.6.x | 0.6.x       |
 | 1.59.0 ≦         | 0.7.x | 0.7.x       |
-| 1.217.0 <=       | 0.8.x | 0.8.x       |
+| 1.217.0 ≦        | 0.8.x | 0.8.x       |
 
 ## Example
 The complete code can be found [here](./examples/src/spanner.rs).

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The list of available features can be found [here](./google-api-proto/Cargo.toml
 |------------------|-------|-------------|
 | 1.0.0 ≦          | 0.6.x | 0.6.x       |
 | 1.59.0 ≦         | 0.7.x | 0.7.x       |
-| 1.219.0 ≦        | 0.8.x | 0.8.x       |
+| 1.223.0 ≦        | 0.8.x | 0.8.x       |
 
 ## Example
 The complete code can be found [here](./examples/src/spanner.rs).

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ The list of available features can be found [here](./google-api-proto/Cargo.toml
 |------------------|-------|-------------|
 | 1.0.0 ≦          | 0.6.x | 0.6.x       |
 | 1.59.0 ≦         | 0.7.x | 0.7.x       |
+| 1.217.0 <=       | 0.8.x | 0.8.x       |
 
 ## Example
 The complete code can be found [here](./examples/src/spanner.rs).
@@ -67,9 +68,9 @@ tokio = { version = "1.15", features = ["macros", "rt-multi-thread"] }
 # For google authentication
 google-authz = { version = "1.0.0-alpha.4", features = ["tonic"] }
 # For gRPC
-tonic = { version = "0.7", features = ["tls", "tls-webpki-roots"] }
-prost = { version = "0.10" }
-prost-types = { version = "0.10" }
+tonic = { version = "0.8", features = ["tls", "tls-webpki-roots"] }
+prost = { version = "0.11" }
+prost-types = { version = "0.11" }
 google-api-proto = { version = "1", features = ["google-spanner-admin-database-v1"] }
 ```
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The list of available features can be found [here](./google-api-proto/Cargo.toml
 |------------------|-------|-------------|
 | 1.0.0 ≦          | 0.6.x | 0.6.x       |
 | 1.59.0 ≦         | 0.7.x | 0.7.x       |
-| 1.218.0 ≦        | 0.8.x | 0.8.x       |
+| 1.219.0 ≦        | 0.8.x | 0.8.x       |
 
 ## Example
 The complete code can be found [here](./examples/src/spanner.rs).

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -9,9 +9,9 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tokio = { version = "1.17", features = ["macros", "rt-multi-thread"] }
 google-authz = { version = "1.0.0-alpha.4", features = ["tonic"] }
 # grpc + gcp
-tonic = { version = "0.7", features = ["tls", "tls-webpki-roots"] }
-prost = "0.10"
-prost-types = "0.10"
+tonic = { version = "0.8", features = ["tls", "tls-webpki-roots"] }
+prost = "0.11"
+prost-types = "0.11"
 
 [dependencies.'google-api-proto']
 path = "../google-api-proto"

--- a/google-api-proto/Cargo.toml
+++ b/google-api-proto/Cargo.toml
@@ -23,9 +23,9 @@ doctest = false
 all-features = true
 
 [dependencies]
-tonic = "0.7"
-prost = "0.10"
-prost-types = "0.10"
+tonic = "0.8"
+prost = "0.11"
+prost-types = "0.11"
 
 [features]
 default = []

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0"
 toml_edit = "0.14"
-prost-build = "0.10.1"
-tonic-build = { version = "0.7", default-features = false, features = ["prost"] }
+prost-build = "0.11"
+tonic-build = { version = "0.8", default-features = false, features = ["prost"] }
 syn = "1.0"
 prettyplease = "0.1"


### PR DESCRIPTION
Fixes #2 

I was able to successfully run:

```
cargo xtask clean generate
```

Not committing the re-generated code here, since a workflow takes care of it.