### PR TITLE
fix workflow

### DIFF
--- a/google-api-proto/Cargo.toml
+++ b/google-api-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "google-api-proto"
-version = "1.695.0"
+version = "1.696.0"
 authors = ["mechiru <u9053u6d41@gmail.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
`pub` workflow is broken.

> error: google-api-proto 1.696.0 is already published

https://github.com/mechiru/google-api-proto/actions/runs/9886330366/job/27305900388#step:7:7032
